### PR TITLE
Update example for 3.14

### DIFF
--- a/index.html
+++ b/index.html
@@ -4343,7 +4343,7 @@ eventHandler = <span class="hljs-function">(<span class="hljs-params">e</span>) 
 					<aside class="example" id="example-43"><div class="marker">
     <a class="self-link" href="#example-43">Example<bdi> 43</bdi></a>
   </div>
-						<pre aria-busy="false"><code class="hljs css"><span class="hljs-keyword">@media</span> screen <span class="hljs-keyword">and</span> (<span class="hljs-attribute">width</span>: <span class="hljs-number">600px</span>) {
+						<pre aria-busy="false"><code class="hljs css"><span class="hljs-keyword">@media</span> screen <span class="hljs-keyword">and</span> (<span class="hljs-attribute">min-width</span>: <span class="hljs-number">600px</span>) {
 	<span class="hljs-selector-tag">body</span> {
 		<span class="hljs-attribute">color</span>: red;
 	}


### PR DESCRIPTION
In a mobile-first logic, we will rather use min-width (from the smallest terminals to the widest) rather than width which only defines rules for a given screen width.