### PR TITLE
Suggested changes to draft IG charter

### DIFF
--- a/ig/charter.html
+++ b/ig/charter.html
@@ -165,15 +165,13 @@
 				<li>Interoperability should be considered where possible for sustainability features that can be machine-tested against. For those lacking machine-testability (due to the nature of their function), notification should be provided stating that automation cannot take place.</li>
 				<li>Having guidance across multiple disciplines of existing web technologies and expertise, and providing well-defined goals that benefit the wide spectrum of sustainability.</li>
 				<li>Aligning published guidance with existing regulatory requirements to increase compliance levels.</li>
-				<li>Feedback to other W3C groups, upon request, regarding sustainability issues in their specifications.</li>
-			</ul>
-			<p>Where scope concerns are not met or areas of concern exist, action will be taken to withhold the offending section from inclusion until a resolution is provided or if consensus cannot be reached, provide a way to provide the information non-normatively until consensus or resolution occurs.</p>
+				</ul>
 			<p>This Interest Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</p>
 		</section>
 		<section id="coordination">
 			<h2>Coordination</h2>
-			<p>For all specifications, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="https://www.w3.org/policies/process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
-			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is advised to seek a review at least 3 months before first entering <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+			<p>For all guidelines, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>. The
+			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is advised to seek a review at least 3 months before any request to advance a Notepatent polciy to W3C Statement.</p>
 			<p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/policies/process/#WGCharter">W3C Process Document</a>:</p>
 			<section>
 				<h3 id="w3c-coordination">W3C Groups</h3>
@@ -210,7 +208,7 @@
 			<h2 id="participation">Participation</h2>
 			<p>To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.</p>
 			<p>The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.</p>
-			<p>The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.</p>
+			<p>The group also welcomes non-Members to contribute technical submissions for consideration.</p>
 			<p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.</p>
 		</section>
 		<section id="communication">

--- a/ig/charter.html
+++ b/ig/charter.html
@@ -171,7 +171,7 @@
 		<section id="coordination">
 			<h2>Coordination</h2>
 			<p>For all guidelines, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>. The
-			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is advised to seek a review at least 3 months before any request to advance a Notepatent polciy to W3C Statement.</p>
+			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is advised to seek a review at least 3 months before any request to advance a Note to W3C Statement.</p>
 			<p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/policies/process/#WGCharter">W3C Process Document</a>:</p>
 			<section>
 				<h3 id="w3c-coordination">W3C Groups</h3>


### PR DESCRIPTION
Some proposed changes:

* Deleted "Feedback to other W3C groups, upon request, regarding sustainability issues in their specifications." because this section is on success criteria for the IG's publications. Also, in previous discussions I suggested that this group (whether WG or IG) not do reviews yet; more experience and community support is, in my view, needed.
* Deleted "Where scope concerns are not met or areas of concern exist..." because it is unnecessary. The W3C Process already says this.
* The second on Coordination still had some remnants of WG stuff, so I made edits departing from the boilerplate. (The [IG boilerplate](https://w3c.github.io/charter-drafts/charter-template.html) is broken and needs to be fixed.)
* Deleted "upon their agreement to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>." The later section (10.) on IPR obligations for participants suffices. (There are no RF patent commitments on IG Notes, so no need for anybody to agree to the patent policy. Section 10. is about disclosure during reviews of other groups' documents. Even though per my above comment I don't think this group should be doing those reviews, it does not hurt to leave section 10. intact to minimize differences from other charters.)
