### PR TITLE
Drop "Normative"

### DIFF
--- a/ig/charter.html
+++ b/ig/charter.html
@@ -124,9 +124,9 @@
 			<p>Updated document status is available on the <i class="todo"><a href="">group publication status page</a>.</i></p>
 			<!-- Provide the IG name: https://www.w3.org/groups/ig/[shortname]/publications -->
 			<p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
-			<section id="normative">
-				<h3>Normative Specifications</h3>
-				<p>The Interest Group will deliver the following W3C normative specifications:</p>
+			<section id="guidelines">
+				<h3>Guidelines</h3>
+				<p>The Interest Group will deliver the following guidelines:</p>
 				<dl>
 					<dt id="web-foo" class="spec"><a href="#">Web Sustainability Guidelines (WSG) 1.0</a></dt>
 					<dd>
@@ -139,7 +139,7 @@
 			</section>
 			<section id="ig-other-deliverables">
 				<h3>Other Deliverables</h3>
-				<p>The Interest Group will publish other non-normative documents:</p>
+				<p>The Group expects to create these deliverables:</p>
 				<ul>
 					<li><a href="https://w3c.github.io/sustyweb/glance.html">At-A-Glance</a> &amp; <a href="https://w3c.github.io/sustyweb/intro.html">Introductory</a> documents offering signposting to the group's work.</li>
 					<li><a href="https://w3c.github.io/sustyweb/quickref.html">Quick Reference</a> &amp; <a href="https://w3c.github.io/sustyweb/checklist.pdf">Checklist</a> which provide a compact list of the WSG's.</li>
@@ -147,7 +147,7 @@
 					<li><a href="https://w3c.github.io/sustyweb/star.html">STAR</a> evaluation methodologies, techniques (case studies), and test suite (metrics).</li>
 					<li><a href="https://w3c.github.io/sustyweb/guidelines.json">JSON API</a> that actively encourages third-party implementation of our work.</li>
 				</ul>
-				<p>Other non-normative documents may be created such as:</p>
+				<p>In addition, the group may work on:</p>
 				<ul>
 					<li>Educational materials to promote adoption.</li>
 					<li>Translations.</li>
@@ -157,7 +157,7 @@
 		</section>
 		<section id="success-criteria">
 			<h2>Success Criteria</h2>
-			<p>In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each normative specification is expected to have undertaken a Wide Review prior to submission.</p>
+			<p>In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each guidelines document is expected to have undertaken a Wide Review prior to submission.</p>
 			<p>Consensus Goals:</p>
 			<ul>
 				<li>Having a maximally impactful set of guidelines as soon as possible that can be iteratively improved upon.</li>


### PR DESCRIPTION
Because this is an Interest Group, it may create confusion to use the word "normative" in this context. I have proposed other verbiage to replace "normative."