### PR TITLE
Suggested adjustments to IG charter

### DIFF
--- a/ig/charter.html
+++ b/ig/charter.html
@@ -129,7 +129,7 @@
 				<dl>
 					<dt id="web-foo" class="spec"><a href="#">Web Sustainability Guidelines (WSG) 1.0</a></dt>
 					<dd>
-						<p>Thes guidelines explain how to design and implement digital products and services that put people and the planet first. The guidelines are best practices based on measurable, evidence-based research; aimed at end-users, web workers, stakeholders, tool authors, educators, and policymakers.</p>
+						<p>These guidelines explain how to design and implement digital products and services that put people and the planet first. The guidelines are best practices based on measurable, evidence-based research; aimed at end-users, web workers, stakeholders, tool authors, educators, and policymakers.</p>
 						<p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/sustyweb/">Adopted from Draft CG Report</a></p>
 						<p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1-4 YYYY]</i></p>
 						<!-- Expected completion date is requird above. -->
@@ -157,7 +157,7 @@
 		<section id="success-criteria">
 			<h2>Success Criteria</h2>
 			<ul>
-				<li>Publish the first draft of the guidelines along with any other associated deliverables.</li>
+				<li>Request the publication of the WSGs as a <a href="https://www.w3.org/policies/process/#w3c-statement">W3C Statement</a>.</li>
 				<li>Provide guidance based upon evidence (where possible), and if evidence is lacking; use industry best practices, develop measurability data, or conduct research to validate claims.</li>
 				<li>Where machine testing of sustainability features is possible, seek interoperable implementations. Where machine-testability is not possible (due to the nature of their function), indicate this in the deliverables.</li>
 				<li>Offer guidance across multiple disciplines of existing web technologies and expertise, and provide well-defined goals that benefit the wide spectrum of sustainability.</li>
@@ -210,7 +210,7 @@
 		</section>
 		<section id="communication">
 			<h2>Communication</h2>
-			<p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however, information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <i class="todo"><a href="">Sustainable Web Interest Group home page.</a></i></p>
+			<p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however, information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <i class="todo"><a href="">Sustainable Web Interest Group home page.</a></i></p>
 			<!-- We will require a shortname for the URL: https://www.w3.org/groups/ig/[shortname]/join -->
 			<p>Most Sustainable Web Interest Group teleconferences will be conducted on an as-needed basis.</p>
 			<p>This group primarily conducts its technical work on <a id="public-github" href="https://github.com/w3c/sustyweb/issues">GitHub issues</a></i>. The public is invited to review, discuss and contribute to this work. This group also uses utilizes the public mailing list <i class="todo"><a id="public-name" href="">public-[email-list]@w3.org</a> (<a href="">archive</a>)</i> for event notifications and important announcements.</p>

--- a/ig/charter.html
+++ b/ig/charter.html
@@ -100,14 +100,13 @@
 		<section id="scope" class="scope">
 			<h2>Scope</h2>
 			<p>The Sustainable Web Interest Group develops and documents guidelines, patterns, processes, and best practices (along with supporting materials) for addressing sustainability issues within digital technology affecting both people and the planet.</p>
-			<p>The group provides coverage for websites &amp; web applications, authoring tools &amp; user agents, user experience design, web development (and tooling), hosting &amp; infrastructure, business &amp; product strategy, and metrics data (concerning research, statistics for measurability, and related weighting of the specification).</p>
+			<p>The group provides coverage for websites &amp; web applications, authoring tools &amp; user agents, user experience design, web development (and tooling), hosting &amp; infrastructure, business &amp; product strategy, and metrics data (concerning research, statistics for measurability, and related weighting of the guidelines).</p>
 			<p>The Interest Group will focus on the following activities:</p>
 			<ul>
 				<li>Publishing a set of guidelines (based upon the <a href="https://w3c.github.io/sustyweb/">CG Draft Report</a>).</li>
-				<li>Iterating and improving these guidelines along with any other deliverables created.</li>
 				<li>Working with regulatory and standards groups to improve compliance targets within our work.</li>
-				<li>Provide improvements upon measurability (how guidelines are endorsed and weighted through quantitative data) to provide more accurate advice within published deliverables.</li>
-				<li>Creating educational materials to improve wider adoption of the guidelines.</li>
+				<li>Improving measurability (how guidelines are endorsed and weighted through quantitative data) to provide more accurate advice within published deliverables.</li>
+				<li>Creating educational materials to foster wider adoption of the guidelines.</li>
 			</ul>
 			<p>The Interest Group may recommend mitigations for sustainability issues in existing features of the Web platform, up to and including their deprecation.</p>
 			<p>The Interest Group may recommend methods to reduce emissions that reinforce (but don't replace) existing beneficial practices (Accessibility, Performance, Privacy, Security, etc).</p>
@@ -123,14 +122,14 @@
 			<h2>Deliverables</h2>
 			<p>Updated document status is available on the <i class="todo"><a href="">group publication status page</a>.</i></p>
 			<!-- Provide the IG name: https://www.w3.org/groups/ig/[shortname]/publications -->
-			<p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+			<p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Group Note, or otherwise reach a stable state.</p>
 			<section id="guidelines">
 				<h3>Guidelines</h3>
 				<p>The Interest Group will deliver the following guidelines:</p>
 				<dl>
 					<dt id="web-foo" class="spec"><a href="#">Web Sustainability Guidelines (WSG) 1.0</a></dt>
 					<dd>
-						<p>This specification explains how to design and implement digital products and services that put people and the planet first. The guidelines are best practices based on measurable, evidence-based research; aimed at end-users, web workers, stakeholders, tool authors, educators, and policymakers.</p>
+						<p>Thes guidelines explain how to design and implement digital products and services that put people and the planet first. The guidelines are best practices based on measurable, evidence-based research; aimed at end-users, web workers, stakeholders, tool authors, educators, and policymakers.</p>
 						<p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/sustyweb/">Adopted from Draft CG Report</a></p>
 						<p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1-4 YYYY]</i></p>
 						<!-- Expected completion date is requird above. -->
@@ -145,42 +144,44 @@
 					<li><a href="https://w3c.github.io/sustyweb/quickref.html">Quick Reference</a> &amp; <a href="https://w3c.github.io/sustyweb/checklist.pdf">Checklist</a> which provide a compact list of the WSG's.</li>
 					<li><a href="https://w3c.github.io/sustyweb/policies.html">Laws & Policies</a> document overviews related regulatory and best practice policies.</li>
 					<li><a href="https://w3c.github.io/sustyweb/star.html">STAR</a> evaluation methodologies, techniques (case studies), and test suite (metrics).</li>
-					<li><a href="https://w3c.github.io/sustyweb/guidelines.json">JSON API</a> that actively encourages third-party implementation of our work.</li>
+					<li><a href="https://w3c.github.io/sustyweb/guidelines.json">JSON API</a> to facilitate third-party implementation of the guidelines.</li>
 				</ul>
 				<p>In addition, the group may work on:</p>
 				<ul>
 					<li>Educational materials to promote adoption.</li>
 					<li>Translations.</li>
 				</ul>
-				<p><strong>Note:</strong> While limited support for browser developers (user-agents) and authoring tools currently exists, the inclusion of materials for such groups in the future is within the scope of this Interest Group.</p>
+				<p><strong>Note:</strong> While limited support for browser developers (user agents) and authoring tools currently exists, the inclusion of materials for such groups in the future is within the scope of this Interest Group.</p>
 			</section>
 		</section>
 		<section id="success-criteria">
 			<h2>Success Criteria</h2>
-			<p>In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each guidelines document is expected to have undertaken a Wide Review prior to submission.</p>
 			<ul>
 				<li>Publish the first draft of the guidelines along with any other associated deliverables.</li>
-				<li>Providing guidance based upon evidence (where possible), and if evidence is lacking; use industry best practices, develop measurability data, or conduct research to validate claims.</li>
-				<li>Interoperability should be considered where possible for sustainability features that can be machine-tested against. For those lacking machine-testability (due to the nature of their function), notification should be provided stating that automation cannot take place.</li>
-				<li>Having guidance across multiple disciplines of existing web technologies and expertise, and providing well-defined goals that benefit the wide spectrum of sustainability.</li>
-				<li>Aligning published guidance with existing regulatory requirements to increase compliance levels.</li>
+				<li>Provide guidance based upon evidence (where possible), and if evidence is lacking; use industry best practices, develop measurability data, or conduct research to validate claims.</li>
+				<li>Where machine testing of sustainability features is possible, seek interoperable implementations. Where machine-testability is not possible (due to the nature of their function), indicate this in the deliverables.</li>
+				<li>Offer guidance across multiple disciplines of existing web technologies and expertise, and provide well-defined goals that benefit the wide spectrum of sustainability.</li>
+				<li>Align published guidance with existing regulatory requirements to increase compliance levels.</li>
 				</ul>
+
+			<p>In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each guidelines document is expected to have undertaken a Wide Review prior to submission.</p>
+		
 			<p>This Interest Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</p>
 		</section>
 		<section id="coordination">
 			<h2>Coordination</h2>
 			<p>For all guidelines, this Interest Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for accessibility, internationalization, privacy, and security with the relevant Working and Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>. The
-			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of each specification. The Interest Group is advised to seek a review at least 3 months before any request to advance a Note to W3C Statement.</p>
+			Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of the guidelines. The Interest Group is advised to seek a review at least 3 months before any request to advance a Note to W3C Statement.</p>
 			<p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/policies/process/#WGCharter">W3C Process Document</a>:</p>
 			<section>
 				<h3 id="w3c-coordination">W3C Groups</h3>
 				<dl>
 					<dt><a href="https://www.w3.org/groups/wg/ag/">Accessibility Guidelines Working Group</a></dt>
-					<dd>For specification guideline modeling and WSG interoperability.</dd>
+					<dd>For guideline modeling and WSG interoperability.</dd>
 					<dt><a href="https://www.w3.org/groups/wg/webperf/">Web Performance Working Group</a></dt>
 					<dd>For guideline interoperability with reducing resource waste.</dd>
 					<dt><a href="https://www.w3.org/groups/cg/sustyweb/">Sustainable Web Design Community Group</a></dt>
-					<dd>The Sustainable Web Interest Group will maintain an ongoing, collaborative relationship with the current Sustainable Web Design community group in order to facilitate knowledge sharing and continuous learning for members of both groups. This will improve the quality of deliverables for both groups.</dd>
+					<dd>The Sustainable Web Interest Group will maintain an ongoing, collaborative relationship with the current Sustainable Web Design Community Group in order to facilitate knowledge sharing and continuous learning for participants of both groups. This will improve the quality of deliverables for both groups.</dd>
 				</dl>
 			</section>
 			<section>
@@ -188,44 +189,44 @@
 				<p>As an emerging and rapidly growing field of knowledge, digital sustainability expertise comes from many places. The Interest Group recognizes that numerous organizations around the world focus on similar or adjacent topics. We have identified the below as early partners whose expertise and willingness to collaborate will support our success.</p>
 				<dl>
 					<dt><a href="https://greensoftware.foundation/">Green Software Foundation</a></dt>
-					<dd>Help the WSGs meet sustainability targets.</dd>
+					<dd>Help align with sustainability targets.</dd>
 					<dt><a href="https://www.thegreenwebfoundation.org/">Green Web Foundation</a></dt>
-					<dd>Help the WSGs meet sustainability targets.</dd>
+					<dd>Help align with sustainability targets.</dd>
 					<dt><a href="https://www.unep.org/topics/digital-transformations/sustainable-digitalization">UNEP CODES</a></dt>
-					<dd>Help the WSGs meet sustainability targets.</dd>
+					<dd>Help align with sustainability targets.</dd>
 				</dl>
-				<p>We will also monitor the work of and where appropriate collaborate with standards bodies (external to the W3C) such as those listed below as their work relates to the compliance adherence work we are including within the specification.</p>
+				<p>We will also monitor the work of and where appropriate collaborate with standards bodies (external to the W3C) such as those listed below as their work relates to the compliance adherence work we are including within the deliverables.</p>
 				<dl>
 					<dt><a href="https://www.globalreporting.org/">Global Reporting Initiative</a></dt>
-					<dd>Help the WSGs meet sustainability targets.</dd>
+					<dd>Help align with sustainability targets.</dd>
 					<dt><a href="https://www.iso.org/committee/10278813.html">International Standards Organization</a></dt>
-					<dd>Help the WSGs meet sustainability targets.</dd>
+					<dd>Help align with sustainability targets.</dd>
 				</dl>
 			</section>
 		</section>
 		<section class="participation">
 			<h2 id="participation">Participation</h2>
-			<p>To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.</p>
+			<p>To be successful, this Interest Group is expected to have 6 or more active participants for its duration, including representatives from the key users of the guidelines, and active Editors and Test Leads. The Chairs, Editors, and Test Leads are expected to contribute half of a working day per week towards the Interest Group. There is no minimum requirement for other Participants.</p>
 			<p>The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.</p>
-			<p>The group also welcomes non-Members to contribute technical submissions for consideration.</p>
+			<p>The group also welcomes non-Members to contribute technical submissions for consideration, although active contributors are expected to join the group.</p>
 			<p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.</p>
 		</section>
 		<section id="communication">
 			<h2>Communication</h2>
-			<p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however, information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <i class="todo"><a href="">Sustainable Web Interest Group home page.</a></i></p>
+			<p id="public">Technical discussions for this Interest Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of will be developed in public repositories and may permit direct public contribution requests. The meetings themselves are not open to public participation, however, information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <i class="todo"><a href="">Sustainable Web Interest Group home page.</a></i></p>
 			<!-- We will require a shortname for the URL: https://www.w3.org/groups/ig/[shortname]/join -->
-			<p>Most Sustainable Web Interest Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.</p>
+			<p>Most Sustainable Web Interest Group teleconferences will be conducted on an as-needed basis.</p>
 			<p>This group primarily conducts its technical work on <a id="public-github" href="https://github.com/w3c/sustyweb/issues">GitHub issues</a></i>. The public is invited to review, discuss and contribute to this work. This group also uses utilizes the public mailing list <i class="todo"><a id="public-name" href="">public-[email-list]@w3.org</a> (<a href="">archive</a>)</i> for event notifications and important announcements.</p>
 			<!--
 				We will require a IG name to associate with a W3C mailing list:
 				mailto:public-[email-list]@w3.org
 				https://lists.w3.org/Archives/Public/public-[email-list]/
 			-->
-			<p>The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.</p>
+			<p>The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and participants of the group, for Member-confidential discussions in special cases when a participant requests such a discussion.</p>
 		</section>
 		<section id="decisions">
 			<h2>Decision Policy</h2>
-			<p>This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/policies/process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+			<p>This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/policies/process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with participants of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
 			<p>However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.</p>
 			<p>To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional. A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue. If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Interest Group.</p>
 			<p>All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.</p>

--- a/ig/charter.html
+++ b/ig/charter.html
@@ -162,10 +162,7 @@
 				<li>Where machine testing of sustainability features is possible, seek interoperable implementations. Where machine-testability is not possible (due to the nature of their function), indicate this in the deliverables.</li>
 				<li>Offer guidance across multiple disciplines of existing web technologies and expertise, and provide well-defined goals that benefit the wide spectrum of sustainability.</li>
 				<li>Align published guidance with existing regulatory requirements to increase compliance levels.</li>
-				</ul>
-
-			<p>In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each guidelines document is expected to have undertaken a Wide Review prior to submission.</p>
-		
+				</ul>		
 			<p>This Interest Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</p>
 		</section>
 		<section id="coordination">


### PR DESCRIPTION
I suggest a number of changes:

* The IG will not publish Recommendations, so I have removed that label.
* I suggest referring to the WSG consistently as "guidelines" and not refer to it as a specification. I have made a number of changes in that direction.
* Similarly, rather than refer to "implementers" I suggest "users" of the guidelines.
* To avoid confusion with "W3C Membership," I tend to refer to "participants of a group" instead of "members of a group".
* This sentence did not add anything substantive to the charter; it just means that work is ongoing, so I deleted it: "Iterating and improving these guidelines along with any other deliverables created."
* Within each bullet list I harmonized the grammatical structure of each bullet.
* Deleted "In order to advance from Note to <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>, each guidelines document is expected to have undertaken a Wide Review prior to submission." because that is already required by the W3C Process for Statements.
* I didn't think it was necessary to constrain the group in the charter by saying "Most Sustainable Web Interest Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis." so I removed the part about focus on specs. 
* Although it may be ok to occasionally receive proposals from non-Members (and non-participants), the expectation should be that regular contributors are participants, and so I added that.
* In addition I made a small number of editorial suggestions.

One question: it does not clearly state that the IG will pursue a W3C Statement within the 2 years of this charter. The text does set expectations that are generally true (about wide review). If the expectation is that the IG will pursue W3C statement within the 2 years, then please change this bullet:

"Publish the first draft of the guidelines along with any other associated deliverables."

to

"Request publication of WSG as a <a href="https://www.w3.org/policies/process/#w3c-statement" title="W3C Statement">W3C Statement</a>."

If the expectation is that the group will not request W3C Statement within 2 years, then it's ok as-is. 