### PR TITLE
editorial: fix link to "on GitHub" to use /ig

### DIFF
--- a/ig/charter.html
+++ b/ig/charter.html
@@ -58,7 +58,7 @@
 			<p class="join"><i class="todo"><a href="">Join the Sustainable Web Interest Group.</a></i></p>
 			<!-- We will require a shortname for the URL: https://www.w3.org/groups/ig/[shortname]/join -->
 		</div>
-		<p class="todo" style="padding: 0.5ex; border: 1px solid green">This proposed charter is available on <a href="https://github.com/w3c/sustyweb/tree/main/wg">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/sustyweb/issues">issues</a>.</p>
+		<p class="todo" style="padding: 0.5ex; border: 1px solid green">This proposed charter is available on <a href="https://github.com/w3c/sustyweb/tree/main/ig/">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/sustyweb/issues">issues</a>.</p>
 		<!-- Note: Delete the GH link after AC review completed. -->
 		<div id="details">
 			<table class="summary-table">


### PR DESCRIPTION
Fix link to "on GitHub" to use /ig instead of /wg