### PR TITLE
restore (2 years) to end date

### DIFF
--- a/ig/charter.html
+++ b/ig/charter.html
@@ -73,7 +73,7 @@
 				</tr>
 				<tr id="CharterEnd">
 					<th>End date</th>
-					<td class="todo">DD Month YYYY</td>
+					<td class="todo">DD Month YYYY (2 years)</td>
 				</tr>
 				<tr>
 					<th>Chairs</th>


### PR DESCRIPTION
suggest restoring " (2 years)" to end date that is in the current IG charter being polled. looks like it may have been accidentally dropped in good faith